### PR TITLE
LIBSEARCH-103. Removed the "aliases" keyword when loading YAML

### DIFF
--- a/config/initializers/internet_archive_searcher_config.rb
+++ b/config/initializers/internet_archive_searcher_config.rb
@@ -8,5 +8,5 @@ config_file = [
 ].find { |file| File.exists? file }
 
 QuickSearch::Engine::INTERNET_ARCHIVE_CONFIG =
-  YAML.load(ERB.new(IO.read(config_file)).result, aliases: true)[Rails.env]
+  YAML.load(ERB.new(IO.read(config_file)).result)[Rails.env]
 QuickSearch::Engine::INTERNET_ARCHIVE_CONFIG.freeze


### PR DESCRIPTION
In Rails 5.2.1.1, the "aliases" keyword is no longer needed (or allowed)
when loading YAML.

https://issues.umd.edu/browse/LIBSEARCH-103