### PR TITLE
LIBSEARCH-159. Modified query so search term is properly escaped

### DIFF
--- a/app/searchers/quick_search/internet_archive_searcher.rb
+++ b/app/searchers/quick_search/internet_archive_searcher.rb
@@ -53,7 +53,7 @@ module QuickSearch
         base = URI.parse host
         params = base_query_params
         params['q'] = (params['q'] +
-                         ["(#{http_request_queries['uri_escaped']})" || ''])
+                         ["(#{@q})" || ''])
                       .join(' AND ')
         base.query = params.to_query
         base


### PR DESCRIPTION
The search term does not need to be escaped when provided to the
"params['q']" object, because the entire params map is subsequently
escaped by the "to_query" method.

https://issues.umd.edu/browse/LIBSEARCH-159